### PR TITLE
fix proposal template errors

### DIFF
--- a/project_name/templates/proposals/proposal_detail.html
+++ b/project_name/templates/proposals/proposal_detail.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load account_tags %}
+{% load bootstrap %}
 
 {% block head_title %}{{ proposal.title }}{% endblock %}
 
@@ -62,7 +63,7 @@
                     {% else %}
                         <p>{% trans 'No supporting documents attached to this proposal.' %}</p>
                     {% endif %}
-                    <a class="btn btn-sm{% if proposal.cancelled %} btn-disabled{% endif %}" href="{% url proposal_document_create proposal.pk %}"><i class="fa fa-upload"></i> {% trans 'Add Document' %}</a>
+                    <a class="btn btn-sm{% if proposal.cancelled %} btn-disabled{% endif %}" href="{% url "proposal_document_create" proposal.pk %}"><i class="fa fa-upload"></i> {% trans 'Add Document' %}</a>
                 </div>
             {% endif %}
 

--- a/project_name/templates/proposals/proposal_edit.html
+++ b/project_name/templates/proposals/proposal_edit.html
@@ -1,7 +1,7 @@
 {% extends "proposals/base.html" %}
 
-{% load bootstrap_tags %}
-{% load markitup %}
+{% load bootstrap %}
+{% load markitup_tags %}
 
 {% block head_title %}Editing {{ proposal.title }}{% endblock %}
 


### PR DESCRIPTION
This change corrects two problems I discovered while working on https://github.com/pydata/conf_site/issues/19

There was a mixup in the bootstrap and markitup_tags names, and a reverse lookup was failing due to missing quotes.