### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Getting Started:
     virtualenv mysiteenv
     source mysiteenv/bin/activate
     pip install Django==1.7.1
-    django-admin.py startproject --template=https://github.com/pinax/pinax-project-account/zipball/master mysite
+    django-admin.py startproject --extension=py,json --template=https://github.com/pinax/pinax-project-symposion/zipball/master <project_name>          
     cd mysite
     pip install -r requirements.txt
     ./manage.py migrate


### PR DESCRIPTION
The readme has it correct in the Usage: area but under getting started the django template links to pinax-project-account instead of pinax-project-symposion

django-admin.py startproject --template=https://github.com/pinax/pinax-project-account/zipball/master mysite

instead of

django-admin.py startproject --extension=py,json --template=https://github.com/pinax/pinax-project-symposion/zipball/master